### PR TITLE
Docs: Improve README for local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ If you'd like to contribute to QSignups, I highly recommend setting up a local d
 git clone https://github.com/evanpetzoldt/qsignups-lambda.git
 ```
 2. Install the [AWS Serverless Application Model (SAM) CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
-3. Set up a local database (code & instructions coming)
+3. Set up a local database 
+    1. Open your terminal and run 'docker run --name qsignups-db -e POSTGRES_USER=local_user -e POSTGRES_PASSWORD=local_password -p 5432:5432 -d postgres'
+    2. Ensure it's running by running 'docker ps' and looking for your database
+    3. Access the db by running 'docker exec -it qsignups-db psql -U local_user postgres'
+    4. At the prompt create the database by running 'CREATE DATABASE f3stcharles;'
+    5. Quit the psql prompt with '\q'
+  Smalle Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
 4. Create the Slack bot: 
-    1. Navigate to [api.slack.com]()
+    1. Navigate to [api.slack.com/apps](https://api.slack.com/apps)
     2. Click "Create an app"
     3. Click "From a manifest", select your workspace
     4. Paste in the manifest below

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     2. Ensure it's running by running `docker ps` and looking for your database
     3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
-    5. Quit the psql prompt with `\q`  
-
+    5. Quit the psql prompt with `\q`  <br>
 
     - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
     5. Quit the psql prompt with `\q`
+
     - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
+    
 4. Create the Slack bot: 
     1. Navigate to [api.slack.com/apps](https://api.slack.com/apps)
     2. Click "Create an app"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     2. Ensure it's running by running `docker ps` and looking for your database
     3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
-    5. Quit the psql prompt with `\q`  <br>
+    5. Quit the psql prompt with `\q`
 
+    <br>
     - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
 
 4. Create the Slack bot: 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     2. Ensure it's running by running `docker ps` and looking for your database
     3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
-    5. Quit the psql prompt with `\q`
+    5. Quit the psql prompt with `\q`  
 
 
     - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
     5. Quit the psql prompt with `\q`
-  Smalle Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
+    - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
 4. Create the Slack bot: 
     1. Navigate to [api.slack.com/apps](https://api.slack.com/apps)
     2. Click "Create an app"

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
     4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
     5. Quit the psql prompt with `\q`
 
+
     - Small Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
-    
+
 4. Create the Slack bot: 
     1. Navigate to [api.slack.com/apps](https://api.slack.com/apps)
     2. Click "Create an app"

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ git clone https://github.com/evanpetzoldt/qsignups-lambda.git
 ```
 2. Install the [AWS Serverless Application Model (SAM) CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
 3. Set up a local database 
-    1. Open your terminal and run 'docker run --name qsignups-db -e POSTGRES_USER=local_user -e POSTGRES_PASSWORD=local_password -p 5432:5432 -d postgres'
-    2. Ensure it's running by running 'docker ps' and looking for your database
-    3. Access the db by running 'docker exec -it qsignups-db psql -U local_user postgres'
-    4. At the prompt create the database by running 'CREATE DATABASE f3stcharles;'
-    5. Quit the psql prompt with '\q'
+    1. Open your terminal and run `docker run --name qsignups-db -e POSTGRES_USER=local_user -e POSTGRES_PASSWORD=local_password -p 5432:5432 -d postgres`
+    2. Ensure it's running by running `docker ps` and looking for your database
+    3. Access the db by running `docker exec -it qsignups-db psql -U local_user postgres`
+    4. At the prompt create the database by running `CREATE DATABASE f3stcharles;`
+    5. Quit the psql prompt with `\q`
   Smalle Note: There are other methods to do this as well, this is just a quick cli version for copypasta.
 4. Create the Slack bot: 
     1. Navigate to [api.slack.com/apps](https://api.slack.com/apps)


### PR DESCRIPTION
This PR updates the README.md to include a clickable link for Slack app creation and provides clearer instructions for local development setup, which uses docker and cli to create a postgres db and configure it.  